### PR TITLE
Trivial - README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A TorChat implementation in Haskell and QML.
     $ cabal sandbox init
     $ cabal install --dependencies-only --enable-tests
     $ cabal build
+    $ cabal install
 ```
 
 ## Run

--- a/hstorchat.cabal
+++ b/hstorchat.cabal
@@ -28,7 +28,8 @@ library
                        safecopy   == 0.8.*,
                        socks      == 0.5.*,
                        tagged     == 0.7.*,
-                       text       == 1.1.*
+                       text       == 1.1.*,
+                       c2hs       == 0.18.*
 
   exposed-modules:     Network.HSTorChat.Client,
                        Network.HSTorChat.GUI,


### PR DESCRIPTION
Without cabal install step hstorchat fails to find torrc file.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
